### PR TITLE
fix: remove % from class names

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the plugin to your `tailwind.config.js`
 ## Usage
 
 ```html
-<div class="gradient-mask-t-0%">
+<div class="gradient-mask-t-0">
     ...
 </div>
 ```

--- a/index.js
+++ b/index.js
@@ -12,18 +12,7 @@ module.exports = plugin(function ({ addUtilities }) {
     tl: "to top left",
   };
 
-  const steps = [
-    "0%",
-    "10%",
-    "20%",
-    "30%",
-    "40%",
-    "50%",
-    "60%",
-    "70%",
-    "80%",
-    "90%",
-  ];
+  const steps = ["0", "10", "20", "30", "40", "50", "60", "70", "80", "90"];
 
   const utilities = Object.entries(directions).reduce(
     (result, [shorthand, direction]) => {
@@ -31,7 +20,7 @@ module.exports = plugin(function ({ addUtilities }) {
         const className = `.gradient-mask-${shorthand}-${step}`;
         return {
           [className]: {
-            maskImage: `linear-gradient(${direction}, rgba(0, 0, 0, 1.0) ${step}, transparent 100%)`,
+            maskImage: `linear-gradient(${direction}, rgba(0, 0, 0, 1.0) ${step}%, transparent 100%)`,
           },
         };
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-gradient-mask-image",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "A plugin for Tailwind CSS for masking elements using mask-image and linear-gradient.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #1 

`%` is not a valid character in a CSS class name so it should not be used.