### PR TITLE
feat: Add -webkitMaskImage for cross-browser gradient mask support

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,12 +22,14 @@ module.exports = plugin(function ({ addUtilities }) {
           const substep = Number(step.split("-")[0]);
           return {
             [className]: {
+              "-webkitMaskImage": `linear-gradient(${direction}, transparent, rgba(0, 0, 0, 1.0) ${100 - substep}%, rgba(0, 0, 0, 1.0) ${substep}%, transparent 100%)`,
               maskImage: `linear-gradient(${direction}, transparent, rgba(0, 0, 0, 1.0) ${100 - substep}%, rgba(0, 0, 0, 1.0) ${substep}%, transparent 100%)`,
             },
           };
         };
         return {
           [className]: {
+            "-webkitMaskImage": `linear-gradient(${direction}, rgba(0, 0, 0, 1.0) ${step}%, transparent 100%)`,
             maskImage: `linear-gradient(${direction}, rgba(0, 0, 0, 1.0) ${step}%, transparent 100%)`,
           },
         };


### PR DESCRIPTION
This PR enhances the existing gradient mask utility in our Tailwind plugin by adding the `-webkitMaskImage` property. This ensures that the gradient mask feature works seamlessly across WebKit-based browsers like Chrome and Safari.

**Changes:**

- Added` -webkitMaskImage` property alongside the existing `maskImage` in the utility generation code.

**Why this change?**

- Provides better cross-browser support, specifically targeting WebKit-based browsers.
- Ensures a more robust and future-proof solution for handling CSS masking.

**Testing:**

- Verified the gradient mask functionality in Chrome, Safari, and Firefox to ensure compatibility.